### PR TITLE
ci: use GH secrets for Playwright E2E Postgres creds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_USER: papyrus_user
-          POSTGRES_PASSWORD: papyrus_password_2024
-          POSTGRES_DB: papyrus_db
+          POSTGRES_USER: ${{ secrets.PG_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.PG_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.PG_DB }}
         ports:
           - 5432:5432
         options: >-
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run DB migrations & seed
         env:
-          DATABASE_URL: postgresql://papyrus_user:papyrus_password_2024@localhost:5432/papyrus_db
+          DATABASE_URL: postgresql://${{ secrets.PG_USER }}:${{ secrets.PG_PASSWORD }}@localhost:5432/${{ secrets.PG_DB }}
         run: |
           npm run test:db:migrate
           npm run test:db:seed
@@ -83,7 +83,7 @@ jobs:
       - name: Start server for E2E
         env:
           PORT: 5001
-          DATABASE_URL: postgresql://papyrus_user:papyrus_password_2024@localhost:5432/papyrus_db
+          DATABASE_URL: postgresql://${{ secrets.PG_USER }}:${{ secrets.PG_PASSWORD }}@localhost:5432/${{ secrets.PG_DB }}
         run: |
           npm run start:e2e &
           echo "Waiting for server to be ready..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,66 @@ jobs:
 
       - name: Build (optional)
         run: npm run build
+
+  playwright-e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: papyrus_user
+          POSTGRES_PASSWORD: papyrus_password_2024
+          POSTGRES_DB: papyrus_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U papyrus_user" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Wait for Postgres
+        run: |
+          echo "Waiting for postgres to be ready..."
+          for i in `seq 1 30`; do
+            pg_isready -h localhost -p 5432 -U papyrus_user && break
+            echo "Waiting... ($i)"
+            sleep 2
+          done
+
+      - name: Run DB migrations & seed
+        env:
+          DATABASE_URL: postgresql://papyrus_user:papyrus_password_2024@localhost:5432/papyrus_db
+        run: |
+          npm run test:db:migrate
+          npm run test:db:seed
+
+      - name: Start server for E2E
+        env:
+          PORT: 5001
+          DATABASE_URL: postgresql://papyrus_user:papyrus_password_2024@localhost:5432/papyrus_db
+        run: |
+          npm run start:e2e &
+          echo "Waiting for server to be ready..."
+          for i in `seq 1 60`; do
+            if curl -sSf http://localhost:5001/ >/dev/null; then
+              echo "Server is up"; break
+            fi
+            sleep 2
+          done
+
+      - name: Run Playwright E2E tests
+        run: npx playwright test --reporter=dot

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- lint-staged

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "lint-staged": {
     "**/*.{js,ts,tsx,json,md,css,scss,html}": [
       "npm run lint:fix",
-      "npm run format",
-      "git add"
+      "npm run format"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,16 @@
     "test:db:seed": "cross-env NODE_ENV=test node --loader ts-node/esm server/migrate-data.js",
     "test:setup": "npm run test:db:migrate && npm run test:db:seed",
     "start:e2e": "cross-env PORT=5001 dotenv -e .env.test -- tsx server/index.ts",
-    "e2e": "cross-env DATABASE_URL=postgresql://papyrus_user:papyrus_password_2024@localhost:5433/papyrus_db npm run test:setup && cross-env DATABASE_URL=postgresql://papyrus_user:papyrus_password_2024@localhost:5433/papyrus_db npx playwright test"
+    "e2e": "cross-env DATABASE_URL=postgresql://papyrus_user:papyrus_password_2024@localhost:5433/papyrus_db npm run test:setup && cross-env DATABASE_URL=postgresql://papyrus_user:papyrus_password_2024@localhost:5433/papyrus_db npx playwright test",
+    "prepare": "husky install"
+  },
+  "prepare": "husky install",
+  "lint-staged": {
+    "**/*.{js,ts,tsx,json,md,css,scss,html}": [
+      "npm run lint:fix",
+      "npm run format",
+      "git add"
+    ]
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -147,6 +156,8 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "husky": "^8.0.0",
+    "lint-staged": "^16.2.0",
     "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.47",


### PR DESCRIPTION
GitHub Actions CI에서 Playwright E2E job이 사용하는 Postgres 자격증명을 하드코딩에서 GitHub Secrets 참조로 교체했습니다.
새로운 CI job playwright-e2e가 추가되어 Postgres 컨테이너를 띄우고 마이그레이션/시드 → 서버 기동 → Playwright 테스트를 실행합니다.
또한 Husky + lint-staged 설정을 통해 로컬 커밋 시 자동으로 lint:fix와 prettier가 실행되도록 구성했습니다 (별도 커밋으로 이미 적용됨).
변경 파일

[ci.yml](vscode-file://vscode-app/c:/Users/joeylife94/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Playwright E2E job 추가
Postgres 자격증명을 secrets(PG_USER, PG_PASSWORD, PG_DB)로 대체
기타: husky / lint-staged 설정 및 docs 관련 커밋(별 커밋으로 적용됨)